### PR TITLE
Update URL and editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Constructable Stylesheet Objects
 
-This specification defines additions to CSSOM to make StyleSheet objects directly constructable, along with methods and APIs to make it easier to deal with stylesheets in the context of custom elements and similar.
+This [specification](https://wicg.github.io/construct-stylesheets/index.html) defines additions to CSSOM to make StyleSheet objects directly constructable, along with methods and APIs to make it easier to deal with stylesheets in the context of custom elements and similar.
 
 For more context, please read the [Explainer](explainer.md).

--- a/index.bs
+++ b/index.bs
@@ -3,8 +3,9 @@ Title: Constructable Stylesheet Objects
 Shortname: construct-stylesheets
 Level: 1
 Status: DREAM
-ED: http://tabatkins.github.io/specs/construct-stylesheets/
+ED: https://wicg.github.io/construct-stylesheets/index.html
 Editor: Tab Atkins Jr., Google, http://xanthir.com/contact/
+Editor: Eric Willigers, Google, ericwilligers@google.com
 Abstract: This draft defines additions to CSSOM to make StyleSheet objects directly constructable, along with methods and APIs to make it easier to deal with stylesheets in the context of custom elements and similar.  It also defines constructors for CSSRule objects.
 Ignored Terms: ShadowRoot, create a medialist object, add a css style sheet, document css style sheets
 </pre>

--- a/index.html
+++ b/index.html
@@ -1177,8 +1177,8 @@ Possible extra rowspan handling
 	}
 </style>
   <meta content="Bikeshed version 67155cabad72a8ab669a7d4421c90e2999a29b68" name="generator">
-  <link href="http://tabatkins.github.io/specs/construct-stylesheets/" rel="canonical">
-  <meta content="952b5af7fb75f00ee3b0e7057c64826531f33de2" name="document-revision">
+  <link href="https://wicg.github.io/construct-stylesheets/index.html" rel="canonical">
+  <meta content="c803160eb9c9424665ee1a89abd4d9b2c79b2884" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1425,21 +1425,22 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Constructable Stylesheet Objects</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-01-30">30 January 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-02-03">3 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="http://tabatkins.github.io/specs/construct-stylesheets/">http://tabatkins.github.io/specs/construct-stylesheets/</a>
+     <dd><a class="u-url" href="https://wicg.github.io/construct-stylesheets/index.html">https://wicg.github.io/construct-stylesheets/index.html</a>
      <dt>Issue Tracking:
      <dd><a href="#issues-index">Inline In Spec</a>
-     <dt class="editor">Editor:
+     <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="http://xanthir.com/contact/">Tab Atkins Jr.</a> (<span class="p-org org">Google</span>)
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:ericwilligers@google.com">Eric Willigers</a> (<span class="p-org org">Google</span>)
     </dl>
    </div>
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 30 January 2018,
+In addition, as of 3 February 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>


### PR DESCRIPTION
New URL: https://wicg.github.io/construct-stylesheets/index.html

Additional editor: Eric Willigers


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ericwilligers/construct-stylesheets/pull/1.html" title="Last updated on Feb 3, 2018, 1:37 AM GMT (2a539a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/1/c803160...ericwilligers:2a539a8.html" title="Last updated on Feb 3, 2018, 1:37 AM GMT (2a539a8)">Diff</a>