### PR TITLE
Remove the sentence from abstract about CSSRule constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,7 @@ Status: DREAM
 ED: https://wicg.github.io/construct-stylesheets/index.html
 Editor: Tab Atkins Jr., Google, http://xanthir.com/contact/
 Editor: Eric Willigers, Google, ericwilligers@google.com
-Abstract: This draft defines additions to CSSOM to make StyleSheet objects directly constructable, along with methods and APIs to make it easier to deal with stylesheets in the context of custom elements and similar.  It also defines constructors for CSSRule objects.
+Abstract: This draft defines additions to CSSOM to make StyleSheet objects directly constructable, along with methods and APIs to make it easier to deal with stylesheets in the context of custom elements and similar.
 Ignored Terms: ShadowRoot, create a medialist object, add a css style sheet, document css style sheets
 </pre>
 


### PR DESCRIPTION
This document doesn't specify any CSSRule constructor.