### PR TITLE
Update spec & explainer to add sync method and clarify behavior

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -1,3 +1,4 @@
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
@@ -17,9 +18,9 @@
 
 A web page may contain tens of thousands of web components. The styles for these components will be specified in a small number of style sheets, perhaps one for each component library.
 
-Each web component uses Shadow DOM. For a style sheet to take effect within the Shadow DOM, it currently must be specified using a style element within each shadow root.
+Most web component uses Shadow DOM. For a style sheet to take effect within the Shadow DOM, it currently must be specified using a `<style>` element within each shadow root. This can easily have a large time and memory cost if user agents force the style sheet rules to be parsed and stored once for every style element. 
 
-This can easily have a large time and memory cost if user agents force the style sheet rules to be parsed and stored once for every style element. Some user agents might attempt to optimize by sharing internal style sheet representations across different instances of the style element. However, component libraries may use JavaScript to modify the style sheet rules, this will thwart style sheet sharing and have large costs in performance and memory.
+Some user agents might attempt to optimize by sharing internal style sheet representations across different instances of the style element. However, component libraries may use JavaScript to modify the style sheet rules, which will thwart style sheet sharing and have large costs in performance and memory.
 
 Often, the main functionality inside the shadow root is provided by a single HTML element that may not itself have children. For a style sheet to also appear inside the shadow root, the shadow root can't be the single HTML element, or a style element, instead it must be a third element that simply contains the style element and the main HTML element that provides the functionality. Thus the shadow root contains three elements when one would otherwise suffice.
 
@@ -29,20 +30,50 @@ Early versions of the Web Component specifications allowed shadow piercing (/dee
 
 ### Proposed Solution
 
-We can provide an API for creating stylesheet objects from script, without needing style elements. Script can optionally add or remove rules from a stylesheet object. Each stylesheet object can be added directly to any number of shadow roots (and/or the top level documemt).
+We can provide an API for creating stylesheet objects from script, without needing style elements. Script can optionally add or remove rules from a stylesheet object. Each stylesheet object can be added directly to any number of shadow roots (and/or the top level document), which are in the same document tree where it is constructed on. 
 
 ### Example Usage
 
-```
+```js
 // Create style sheet when registering components.
-let styleSheetList = new StyleSheetList([
-    await document.createCSSStyleSheet("hr { color: green; }")
-]);
-
-// ...
+let someStyleSheet = document.createCSSStyleSheetSync("hr { color: green}");
+let anotherStyleSheet = await document.createCSSStyleSheet("@import fancystyle.css")
 
 // Apply style sheet in custom element constructor.
-shadowRoot.adoptedStyleSheets = styleSheetList;
+shadowRoot.adoptedStyleSheets = new StyleSheetList([someStyleSheet, anotherStyleSheet]);
+
+// Apply style sheet in top level document.
+document.adoptedStyleSheets = new StyleSheetList([someStyleSheet]);
 ```
+
+### Behavior
+* Each constructed `CSSStyleSheet` is "tied" to the `Document` it is constructed on, meaning that it can only be used in that document tree (whether in a top-level document or shadow trees).
+	* Example:
+	```html
+	<body>
+	<iframe id="someFrame">some frame</iframe>
+	<div id="someDiv">some div</div>
+	</body>
+	<script>
+		let sheetList = new StyleSheetList([
+			document.createCSSStyleSheetSync("* { color: red; })")
+		]);
+		// this will fail
+		someFrame.contentDocument.adoptedStyleSheets = sheetList;
+		// this will work
+		let shadowRoot = someDiv.attachShadow({mode: "open"});
+		shadowRoot.adoptedStyleSheets = sheetList;
+	</script>
+	```
+* After a stylesheet is added to `DocumentOrShadowRoot`s, changes made to the stylesheet will also reflect in those `DocumentOrShadowRoot`s.
+	* Example:
+	```js
+	let sheet = document.createCSSStyleSheetSync("* { color: red; })");
+	document.adoptedStyleSheets = new StyleSheetList([sheet]);
+	sheet.insertRule("* { background-color: blue; }");
+	// Now document will have blue background color as well.
+	```
+* Stylesheets added to `adoptedStyleSheets` are part of the `DocumentOrShadowRoot`'s style sheets, and they are ordered after  the`DocumentOrShadowRoot`'s `styleSheets`.
+	* This means when there are conflicting rules in the `adoptedStyleSheets` and `styleSheets` and the resolution will consider the order of stylesheets, they treat the sheets in `adoptedStyleSheets` as ordered later.
 
 

--- a/index.bs
+++ b/index.bs
@@ -21,6 +21,7 @@ Constructing Stylesheets {#constructing-stylesheets}
 <pre class='idl'>
 partial interface Document {
 	[NewObject] Promise&lt;CSSStyleSheet> createCSSStyleSheet(DOMString text, optional CSSStyleSheetInit options);
+	[NewObject] CSSStyleSheet createCSSStyleSheetSync(DOMString text, optional CSSStyleSheetInit options);
 	[NewObject] CSSStyleSheet createEmptyCSSStyleSheet(optional CSSStyleSheetInit options);
 };
 
@@ -65,6 +66,34 @@ dictionary CSSStyleSheetInit {
 		8. Return <var>promise</var>.
 	</dd>
 
+    <dt><dfn method for=Document lt="createCSSStyleSheetSync(text)|createCSSStyleSheetSync(text, options)">createCSSStyleSheetSync(text, options)</dfn></dt>
+	<dd>
+		When called, execute these steps:
+
+		1. Construct a new {{CSSStyleSheet}} object <var>sheet</var>,
+			with location set to the {{Document}}'s <a spec=html>base URL</a>,
+			no parent CSS style sheet,
+			no owner node,
+			no owner CSS rule,
+			and a title set to the {{CSSStyleSheetInit/title}} attribute of <var>options</var>.
+			Set <var>sheet’s</var> origin-clean flag.
+		2. If the {{CSSStyleSheetInit/media}} attribute of <var>options</var> is a string,
+			<a>create a MediaList object</a> from the string
+			and assign it as <var>sheet’s</var> media.
+			Otherwise, assign a copy of the value of the attribute as <var>sheet’s</var> media.
+		3. If the {{CSSStyleSheetInit/alternate}} attribute of <var>options</var> is true,
+			set <var>sheet’s</var> alternate flag.
+		4. If the {{CSSStyleSheetInit/disabled}} attribute of <var>options</var> is true,
+			set <var>sheet’s</var> disabled flag.
+		5. <a spec=css-syntax-3>Parse a stylesheet</a> from {{text}}.
+			If it returned a list of rules,
+			assign the list as <var>sheet’s</var> CSS rules;
+			otherwise,
+			set <var>sheet’s</var> CSS rules to an empty list.
+		6. If <var>sheet</var> contains one or more <a spec=css-cascade-4>@import</a> rules, throw a {{SyntaxError}}.
+		7. Return <var>sheet</var>.
+	</dd>
+
 	<dt><dfn method for=Document lt="createEmptyCSSStyleSheet()|createEmptyCSSStyleSheet(options)">createEmptyCSSStyleSheet(options)</dfn></dt>
 	<dd>
 		Synchronously creates an empty CSSStyleSheet object and returns it.
@@ -93,8 +122,9 @@ dictionary CSSStyleSheetInit {
 Using Constructed Stylesheets {#using-constructed-stylesheets}
 =============================
 
-A {{CSSStyleSheet}} can only be applied to the {{Document}} it is constructed on, or any {{ShadowRoot}} in the {{Document}} it is constructed on,
-by adding a {{StyleSheetList}} containing the sheet to their {{adoptedStyleSheets}}. A stylesheet can be used in multiple {{DocumentOrShadowRoot}}s.
+A {{CSSStyleSheet}} can only be applied to the {{Document}} it is constructed on (e.g. the document on which the factory function is called on),
+and any {{ShadowRoot}} in the {{Document}} it is constructed on, by adding a {{StyleSheetList}} containing the sheet to their {{adoptedStyleSheets}}.
+So, a stylesheet can be used in multiple {{DocumentOrShadowRoot}}s within the document it is constructed on.
 
 Non-explicitly constructed stylesheets cannot be added to {{adoptedStyleSheets}}.
 If {{adoptedStyleSheets}} got assigned a {{StyleSheetList}} that contains style sheets not made by {{createCSSStyleSheet(text)}} or {{createEmptyCSSStyleSheet}},

--- a/index.html
+++ b/index.html
@@ -1212,7 +1212,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 090ef96cbce74475c89e94394cc8fa4fbc08b477" name="generator">
+  <meta content="Bikeshed version 018be3f805d3272ce699a232398d6e3902d1ea8d" name="generator">
   <link href="https://wicg.github.io/construct-stylesheets/index.html" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1460,7 +1460,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Constructable Stylesheet Objects</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-09-11">11 September 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-10-16">16 October 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1474,7 +1474,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 11 September 2018,
+In addition, as of 16 October 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1510,12 +1510,13 @@ Parts of this work may be from another specification document.  If so, those par
    <h2 class="heading settled" data-level="1" id="constructing-stylesheets"><span class="secno">1. </span><span class="content">Constructing Stylesheets</span><a class="self-link" href="#constructing-stylesheets"></a></h2>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document"><c- g>Document</c-></a> {
   [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject"><c- g>NewObject</c-></a>] <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet"><c- n>CSSStyleSheet</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-document-createcssstylesheet" id="ref-for-dom-document-createcssstylesheet"><c- g>createCSSStyleSheet</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Document/createCSSStyleSheet(text, options), Document/createCSSStyleSheet(text)" data-dfn-type="argument" data-export id="dom-document-createcssstylesheet-text-options-text"><code><c- g>text</c-></code></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit"><c- n>CSSStyleSheetInit</c-></a> <dfn class="idl-code" data-dfn-for="Document/createCSSStyleSheet(text, options), Document/createCSSStyleSheet(text)" data-dfn-type="argument" data-export id="dom-document-createcssstylesheet-text-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-document-createcssstylesheet-text-options-options"></a></dfn>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet①"><c- n>CSSStyleSheet</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createemptycssstylesheet" id="ref-for-dom-document-createemptycssstylesheet"><c- g>createEmptyCSSStyleSheet</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit①"><c- n>CSSStyleSheetInit</c-></a> <dfn class="idl-code" data-dfn-for="Document/createEmptyCSSStyleSheet(options), Document/createEmptyCSSStyleSheet()" data-dfn-type="argument" data-export id="dom-document-createemptycssstylesheet-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-document-createemptycssstylesheet-options-options"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet①"><c- n>CSSStyleSheet</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createcssstylesheetsync" id="ref-for-dom-document-createcssstylesheetsync"><c- g>createCSSStyleSheetSync</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Document/createCSSStyleSheetSync(text, options), Document/createCSSStyleSheetSync(text)" data-dfn-type="argument" data-export id="dom-document-createcssstylesheetsync-text-options-text"><code><c- g>text</c-></code><a class="self-link" href="#dom-document-createcssstylesheetsync-text-options-text"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit①"><c- n>CSSStyleSheetInit</c-></a> <dfn class="idl-code" data-dfn-for="Document/createCSSStyleSheetSync(text, options), Document/createCSSStyleSheetSync(text)" data-dfn-type="argument" data-export id="dom-document-createcssstylesheetsync-text-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-document-createcssstylesheetsync-text-options-options"></a></dfn>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject②"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet②"><c- n>CSSStyleSheet</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createemptycssstylesheet" id="ref-for-dom-document-createemptycssstylesheet"><c- g>createEmptyCSSStyleSheet</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit②"><c- n>CSSStyleSheetInit</c-></a> <dfn class="idl-code" data-dfn-for="Document/createEmptyCSSStyleSheet(options), Document/createEmptyCSSStyleSheet()" data-dfn-type="argument" data-export id="dom-document-createemptycssstylesheet-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-document-createemptycssstylesheet-options-options"></a></dfn>);
 };
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-cssstylesheetinit"><code><c- g>CSSStyleSheetInit</c-></code></dfn> {
-  (<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#medialist" id="ref-for-medialist"><c- n>MediaList</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a>) <dfn class="dfn-paneled idl-code" data-default="&quot;&quot;" data-dfn-for="CSSStyleSheetInit" data-dfn-type="dict-member" data-export data-type="(MediaList or DOMString) " id="dom-cssstylesheetinit-media"><code><c- g>media</c-></code></dfn> = "";
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-default="&quot;&quot;" data-dfn-for="CSSStyleSheetInit" data-dfn-type="dict-member" data-export data-type="DOMString " id="dom-cssstylesheetinit-title"><code><c- g>title</c-></code></dfn> = "";
+  (<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#medialist" id="ref-for-medialist"><c- n>MediaList</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a>) <dfn class="dfn-paneled idl-code" data-default="&quot;&quot;" data-dfn-for="CSSStyleSheetInit" data-dfn-type="dict-member" data-export data-type="(MediaList or DOMString) " id="dom-cssstylesheetinit-media"><code><c- g>media</c-></code></dfn> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-default="&quot;&quot;" data-dfn-for="CSSStyleSheetInit" data-dfn-type="dict-member" data-export data-type="DOMString " id="dom-cssstylesheetinit-title"><code><c- g>title</c-></code></dfn> = "";
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="CSSStyleSheetInit" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-cssstylesheetinit-alternate"><code><c- g>alternate</c-></code></dfn> = <c- b>false</c->;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-default="false" data-dfn-for="CSSStyleSheetInit" data-dfn-type="dict-member" data-export data-type="boolean " id="dom-cssstylesheetinit-disabled"><code><c- g>disabled</c-></code></dfn> = <c- b>false</c->;
 };
@@ -1526,7 +1527,7 @@ Parts of this work may be from another specification document.  If so, those par
       When called, execute these steps: 
      <ol>
       <li data-md>
-       <p>Construct a new <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet②">CSSStyleSheet</a></code> object <var>sheet</var>,
+       <p>Construct a new <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet③">CSSStyleSheet</a></code> object <var>sheet</var>,
 with location set to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url" id="ref-for-concept-script-base-url">base URL</a>,
 no parent CSS style sheet,
 no owner node,
@@ -1564,13 +1565,12 @@ set <var>sheet’s</var> CSS rules to an empty list.</p>
       <li data-md>
        <p>Return <var>promise</var>.</p>
      </ol>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="createEmptyCSSStyleSheet()|createEmptyCSSStyleSheet(options)" id="dom-document-createemptycssstylesheet"><code>createEmptyCSSStyleSheet(options)</code></dfn>
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="createCSSStyleSheetSync(text)|createCSSStyleSheetSync(text, options)" id="dom-document-createcssstylesheetsync"><code>createCSSStyleSheetSync(text, options)</code></dfn>
     <dd>
-      Synchronously creates an empty CSSStyleSheet object and returns it. 
-     <p>When called, execute these steps:</p>
+      When called, execute these steps: 
      <ol>
       <li data-md>
-       <p>Construct a new <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet③">CSSStyleSheet</a></code> object <var>sheet</var>,
+       <p>Construct a new <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet④">CSSStyleSheet</a></code> object <var>sheet</var>,
 with location set to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url" id="ref-for-concept-script-base-url①">base URL</a>,
 no parent CSS style sheet,
 no owner node,
@@ -1588,12 +1588,47 @@ set <var>sheet’s</var> alternate flag.</p>
        <p>If the <code class="idl"><a data-link-type="idl" href="#dom-cssstylesheetinit-disabled" id="ref-for-dom-cssstylesheetinit-disabled①">disabled</a></code> attribute of <var>options</var> is true,
 set <var>sheet’s</var> disabled flag.</p>
       <li data-md>
+       <p><a data-link-type="dfn" href="https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet" id="ref-for-parse-a-stylesheet①">Parse a stylesheet</a> from <code class="idl"><a data-link-type="idl" href="#dom-document-createcssstylesheet-text-options-text" id="ref-for-dom-document-createcssstylesheet-text-options-text①">text</a></code>.
+If it returned a list of rules,
+assign the list as <var>sheet’s</var> CSS rules;
+otherwise,
+set <var>sheet’s</var> CSS rules to an empty list.</p>
+      <li data-md>
+       <p>If <var>sheet</var> contains one or more <a class="css" data-link-type="at-rule" href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import" id="ref-for-at-ruledef-import①">@import</a> rules, throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror" id="ref-for-syntaxerror">SyntaxError</a></code>.</p>
+      <li data-md>
+       <p>Return <var>sheet</var>.</p>
+     </ol>
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="createEmptyCSSStyleSheet()|createEmptyCSSStyleSheet(options)" id="dom-document-createemptycssstylesheet"><code>createEmptyCSSStyleSheet(options)</code></dfn>
+    <dd>
+      Synchronously creates an empty CSSStyleSheet object and returns it. 
+     <p>When called, execute these steps:</p>
+     <ol>
+      <li data-md>
+       <p>Construct a new <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet⑤">CSSStyleSheet</a></code> object <var>sheet</var>,
+with location set to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url" id="ref-for-concept-script-base-url②">base URL</a>,
+no parent CSS style sheet,
+no owner node,
+no owner CSS rule,
+and a title set to the <code class="idl"><a data-link-type="idl" href="#dom-cssstylesheetinit-title" id="ref-for-dom-cssstylesheetinit-title②">title</a></code> attribute of <var>options</var>.
+Set <var>sheet’s</var> origin-clean flag.</p>
+      <li data-md>
+       <p>If the <code class="idl"><a data-link-type="idl" href="#dom-cssstylesheetinit-media" id="ref-for-dom-cssstylesheetinit-media②">media</a></code> attribute of <var>options</var> is a string, <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#create-a-medialist-object" id="ref-for-create-a-medialist-object②">create a MediaList object</a> from the string
+and assign it as <var>sheet’s</var> media.
+Otherwise, assign a copy of the value of the attribute as <var>sheet’s</var> media.</p>
+      <li data-md>
+       <p>If the <code class="idl"><a data-link-type="idl" href="#dom-cssstylesheetinit-alternate" id="ref-for-dom-cssstylesheetinit-alternate②">alternate</a></code> attribute of <var>options</var> is true,
+set <var>sheet’s</var> alternate flag.</p>
+      <li data-md>
+       <p>If the <code class="idl"><a data-link-type="idl" href="#dom-cssstylesheetinit-disabled" id="ref-for-dom-cssstylesheetinit-disabled②">disabled</a></code> attribute of <var>options</var> is true,
+set <var>sheet’s</var> disabled flag.</p>
+      <li data-md>
        <p>Return <var>sheet</var>.</p>
      </ol>
    </dl>
    <h2 class="heading settled" data-level="2" id="using-constructed-stylesheets"><span class="secno">2. </span><span class="content">Using Constructed Stylesheets</span><a class="self-link" href="#using-constructed-stylesheets"></a></h2>
-   <p>A <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet④">CSSStyleSheet</a></code> can only be applied to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> it is constructed on, or any <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot">ShadowRoot</a></code> in the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> it is constructed on,
-by adding a <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#stylesheetlist" id="ref-for-stylesheetlist">StyleSheetList</a></code> containing the sheet to their <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</a></code>. A stylesheet can be used in multiple <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot">DocumentOrShadowRoot</a></code>s.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet⑥">CSSStyleSheet</a></code> can only be applied to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> it is constructed on (e.g. the document on which the factory function is called on),
+and any <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot">ShadowRoot</a></code> in the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> it is constructed on, by adding a <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#stylesheetlist" id="ref-for-stylesheetlist">StyleSheetList</a></code> containing the sheet to their <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</a></code>.
+So, a stylesheet can be used in multiple <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot">DocumentOrShadowRoot</a></code>s within the document it is constructed on.</p>
    <p>Non-explicitly constructed stylesheets cannot be added to <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets①">adoptedStyleSheets</a></code>.
 If <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets②">adoptedStyleSheets</a></code> got assigned a <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#stylesheetlist" id="ref-for-stylesheetlist①">StyleSheetList</a></code> that contains style sheets not made by <code class="idl"><a data-link-type="idl" href="#dom-document-createcssstylesheet" id="ref-for-dom-document-createcssstylesheet①">createCSSStyleSheet(text)</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-document-createemptycssstylesheet" id="ref-for-dom-document-createemptycssstylesheet①">createEmptyCSSStyleSheet</a></code>,
 a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code> will be thrown.</p>
@@ -1765,6 +1800,8 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
   <ul class="index">
    <li><a href="#dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</a><span>, in §2</span>
    <li><a href="#dom-cssstylesheetinit-alternate">alternate</a><span>, in §1</span>
+   <li><a href="#dom-document-createcssstylesheetsync">createCSSStyleSheetSync(text)</a><span>, in §1</span>
+   <li><a href="#dom-document-createcssstylesheetsync">createCSSStyleSheetSync(text, options)</a><span>, in §1</span>
    <li><a href="#dom-document-createcssstylesheet">createCSSStyleSheet(text)</a><span>, in §1</span>
    <li><a href="#dom-document-createcssstylesheet">createCSSStyleSheet(text, options)</a><span>, in §1</span>
    <li><a href="#dom-document-createemptycssstylesheet">createEmptyCSSStyleSheet()</a><span>, in §1</span>
@@ -1779,20 +1816,20 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
   <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
    <a href="https://drafts.csswg.org/css-cascade-4/#at-ruledef-import">https://drafts.csswg.org/css-cascade-4/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-at-ruledef-import">1. Constructing Stylesheets</a>
+    <li><a href="#ref-for-at-ruledef-import">1. Constructing Stylesheets</a> <a href="#ref-for-at-ruledef-import①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-parse-a-stylesheet">
    <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet">https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-stylesheet">1. Constructing Stylesheets</a>
+    <li><a href="#ref-for-parse-a-stylesheet">1. Constructing Stylesheets</a> <a href="#ref-for-parse-a-stylesheet①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-cssstylesheet">
    <a href="https://drafts.csswg.org/cssom-1/#cssstylesheet">https://drafts.csswg.org/cssom-1/#cssstylesheet</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-cssstylesheet">1. Constructing Stylesheets</a> <a href="#ref-for-cssstylesheet①">(2)</a> <a href="#ref-for-cssstylesheet②">(3)</a> <a href="#ref-for-cssstylesheet③">(4)</a>
-    <li><a href="#ref-for-cssstylesheet④">2. Using Constructed Stylesheets</a>
+    <li><a href="#ref-for-cssstylesheet">1. Constructing Stylesheets</a> <a href="#ref-for-cssstylesheet①">(2)</a> <a href="#ref-for-cssstylesheet②">(3)</a> <a href="#ref-for-cssstylesheet③">(4)</a> <a href="#ref-for-cssstylesheet④">(5)</a> <a href="#ref-for-cssstylesheet⑤">(6)</a>
+    <li><a href="#ref-for-cssstylesheet⑥">2. Using Constructed Stylesheets</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-medialist">
@@ -1816,7 +1853,7 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
   <aside class="dfn-panel" data-for="term-for-create-a-medialist-object">
    <a href="https://drafts.csswg.org/cssom-1/#create-a-medialist-object">https://drafts.csswg.org/cssom-1/#create-a-medialist-object</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-create-a-medialist-object">1. Constructing Stylesheets</a> <a href="#ref-for-create-a-medialist-object①">(2)</a>
+    <li><a href="#ref-for-create-a-medialist-object">1. Constructing Stylesheets</a> <a href="#ref-for-create-a-medialist-object①">(2)</a> <a href="#ref-for-create-a-medialist-object②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document-document-css-style-sheets">
@@ -1834,8 +1871,8 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
   <aside class="dfn-panel" data-for="term-for-document">
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document">1. Constructing Stylesheets</a> <a href="#ref-for-document①">(2)</a> <a href="#ref-for-document②">(3)</a>
-    <li><a href="#ref-for-document③">2. Using Constructed Stylesheets</a> <a href="#ref-for-document④">(2)</a>
+    <li><a href="#ref-for-document">1. Constructing Stylesheets</a> <a href="#ref-for-document①">(2)</a> <a href="#ref-for-document②">(3)</a> <a href="#ref-for-document③">(4)</a>
+    <li><a href="#ref-for-document④">2. Using Constructed Stylesheets</a> <a href="#ref-for-document⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
@@ -1853,7 +1890,7 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
   <aside class="dfn-panel" data-for="term-for-concept-script-base-url">
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-script-base-url">1. Constructing Stylesheets</a> <a href="#ref-for-concept-script-base-url①">(2)</a>
+    <li><a href="#ref-for-concept-script-base-url">1. Constructing Stylesheets</a> <a href="#ref-for-concept-script-base-url①">(2)</a> <a href="#ref-for-concept-script-base-url②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-content-type">
@@ -1871,13 +1908,19 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
    <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-idl-DOMString">1. Constructing Stylesheets</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
+    <li><a href="#ref-for-idl-DOMString">1. Constructing Stylesheets</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-NewObject">
    <a href="https://heycam.github.io/webidl/#NewObject">https://heycam.github.io/webidl/#NewObject</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-NewObject">1. Constructing Stylesheets</a> <a href="#ref-for-NewObject①">(2)</a>
+    <li><a href="#ref-for-NewObject">1. Constructing Stylesheets</a> <a href="#ref-for-NewObject①">(2)</a> <a href="#ref-for-NewObject②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-syntaxerror">
+   <a href="https://heycam.github.io/webidl/#syntaxerror">https://heycam.github.io/webidl/#syntaxerror</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-syntaxerror">1. Constructing Stylesheets</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
@@ -1935,6 +1978,7 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
      <li><span class="dfn-paneled" id="term-for-idl-DOMException" style="color:initial">DOMException</span>
      <li><span class="dfn-paneled" id="term-for-idl-DOMString" style="color:initial">DOMString</span>
      <li><span class="dfn-paneled" id="term-for-NewObject" style="color:initial">NewObject</span>
+     <li><span class="dfn-paneled" id="term-for-syntaxerror" style="color:initial">SyntaxError</span>
      <li><span class="dfn-paneled" id="term-for-exceptiondef-typeerror" style="color:initial">TypeError</span>
      <li><span class="dfn-paneled" id="term-for-idl-boolean" style="color:initial">boolean</span>
     </ul>
@@ -1958,14 +2002,15 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
    <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤"><c- g>Document</c-></a> {
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject②"><c- g>NewObject</c-></a>] <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet⑤"><c- n>CSSStyleSheet</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-document-createcssstylesheet" id="ref-for-dom-document-createcssstylesheet②"><c- g>createCSSStyleSheet</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <a href="#dom-document-createcssstylesheet-text-options-text"><code><c- g>text</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit②"><c- n>CSSStyleSheetInit</c-></a> <a href="#dom-document-createcssstylesheet-text-options-options"><code><c- g>options</c-></code></a>);
-  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet①①"><c- n>CSSStyleSheet</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createemptycssstylesheet" id="ref-for-dom-document-createemptycssstylesheet②"><c- g>createEmptyCSSStyleSheet</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit①①"><c- n>CSSStyleSheetInit</c-></a> <a href="#dom-document-createemptycssstylesheet-options-options"><code><c- g>options</c-></code></a>);
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥"><c- g>Document</c-></a> {
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject③"><c- g>NewObject</c-></a>] <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet⑦"><c- n>CSSStyleSheet</c-></a>> <a class="idl-code" data-link-type="method" href="#dom-document-createcssstylesheet" id="ref-for-dom-document-createcssstylesheet②"><c- g>createCSSStyleSheet</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <a href="#dom-document-createcssstylesheet-text-options-text"><code><c- g>text</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit③"><c- n>CSSStyleSheetInit</c-></a> <a href="#dom-document-createcssstylesheet-text-options-options"><code><c- g>options</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject①①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet①①"><c- n>CSSStyleSheet</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createcssstylesheetsync" id="ref-for-dom-document-createcssstylesheetsync①"><c- g>createCSSStyleSheetSync</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a> <a href="#dom-document-createcssstylesheetsync-text-options-text"><code><c- g>text</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit①①"><c- n>CSSStyleSheetInit</c-></a> <a href="#dom-document-createcssstylesheetsync-text-options-options"><code><c- g>options</c-></code></a>);
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#NewObject" id="ref-for-NewObject②①"><c- g>NewObject</c-></a>] <a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet②①"><c- n>CSSStyleSheet</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-createemptycssstylesheet" id="ref-for-dom-document-createemptycssstylesheet②"><c- g>createEmptyCSSStyleSheet</c-></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-cssstylesheetinit" id="ref-for-dictdef-cssstylesheetinit②①"><c- n>CSSStyleSheetInit</c-></a> <a href="#dom-document-createemptycssstylesheet-options-options"><code><c- g>options</c-></code></a>);
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-cssstylesheetinit"><code><c- g>CSSStyleSheetInit</c-></code></a> {
-  (<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#medialist" id="ref-for-medialist①"><c- n>MediaList</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a>) <a data-default="&quot;&quot;" data-type="(MediaList or DOMString) " href="#dom-cssstylesheetinit-media"><code><c- g>media</c-></code></a> = "";
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-cssstylesheetinit-title"><code><c- g>title</c-></code></a> = "";
+  (<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#medialist" id="ref-for-medialist①"><c- n>MediaList</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a>) <a data-default="&quot;&quot;" data-type="(MediaList or DOMString) " href="#dom-cssstylesheetinit-media"><code><c- g>media</c-></code></a> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a> <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-cssstylesheetinit-title"><code><c- g>title</c-></code></a> = "";
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-cssstylesheetinit-alternate"><code><c- g>alternate</c-></code></a> = <c- b>false</c->;
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-cssstylesheetinit-disabled"><code><c- g>disabled</c-></code></a> = <c- b>false</c->;
 };
@@ -1982,37 +2027,37 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
   <aside class="dfn-panel" data-for="dom-document-createcssstylesheet-text-options-text">
    <b><a href="#dom-document-createcssstylesheet-text-options-text">#dom-document-createcssstylesheet-text-options-text</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-document-createcssstylesheet-text-options-text">1. Constructing Stylesheets</a>
+    <li><a href="#ref-for-dom-document-createcssstylesheet-text-options-text">1. Constructing Stylesheets</a> <a href="#ref-for-dom-document-createcssstylesheet-text-options-text①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-cssstylesheetinit">
    <b><a href="#dictdef-cssstylesheetinit">#dictdef-cssstylesheetinit</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-cssstylesheetinit">1. Constructing Stylesheets</a> <a href="#ref-for-dictdef-cssstylesheetinit①">(2)</a>
+    <li><a href="#ref-for-dictdef-cssstylesheetinit">1. Constructing Stylesheets</a> <a href="#ref-for-dictdef-cssstylesheetinit①">(2)</a> <a href="#ref-for-dictdef-cssstylesheetinit②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-cssstylesheetinit-media">
    <b><a href="#dom-cssstylesheetinit-media">#dom-cssstylesheetinit-media</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-cssstylesheetinit-media">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-media①">(2)</a>
+    <li><a href="#ref-for-dom-cssstylesheetinit-media">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-media①">(2)</a> <a href="#ref-for-dom-cssstylesheetinit-media②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-cssstylesheetinit-title">
    <b><a href="#dom-cssstylesheetinit-title">#dom-cssstylesheetinit-title</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-cssstylesheetinit-title">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-title①">(2)</a>
+    <li><a href="#ref-for-dom-cssstylesheetinit-title">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-title①">(2)</a> <a href="#ref-for-dom-cssstylesheetinit-title②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-cssstylesheetinit-alternate">
    <b><a href="#dom-cssstylesheetinit-alternate">#dom-cssstylesheetinit-alternate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-cssstylesheetinit-alternate">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-alternate①">(2)</a>
+    <li><a href="#ref-for-dom-cssstylesheetinit-alternate">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-alternate①">(2)</a> <a href="#ref-for-dom-cssstylesheetinit-alternate②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-cssstylesheetinit-disabled">
    <b><a href="#dom-cssstylesheetinit-disabled">#dom-cssstylesheetinit-disabled</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-cssstylesheetinit-disabled">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-disabled①">(2)</a>
+    <li><a href="#ref-for-dom-cssstylesheetinit-disabled">1. Constructing Stylesheets</a> <a href="#ref-for-dom-cssstylesheetinit-disabled①">(2)</a> <a href="#ref-for-dom-cssstylesheetinit-disabled②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-document-createcssstylesheet">
@@ -2020,6 +2065,12 @@ a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webid
    <ul>
     <li><a href="#ref-for-dom-document-createcssstylesheet">1. Constructing Stylesheets</a>
     <li><a href="#ref-for-dom-document-createcssstylesheet①">2. Using Constructed Stylesheets</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-document-createcssstylesheetsync">
+   <b><a href="#dom-document-createcssstylesheetsync">#dom-document-createcssstylesheetsync</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-document-createcssstylesheetsync">1. Constructing Stylesheets</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-document-createemptycssstylesheet">


### PR DESCRIPTION
Adding `document.createCSSStyleSheetSync` and updated explainer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/pull/39.html" title="Last updated on Oct 16, 2018, 11:10 AM GMT (7de153e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/39/8cbe2f4...7de153e.html" title="Last updated on Oct 16, 2018, 11:10 AM GMT (7de153e)">Diff</a>