### PR TITLE
Avoid using "index.html" as part of the canonical URL.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,7 @@ Title: Constructable Stylesheet Objects
 Shortname: construct-stylesheets
 Level: 1
 Status: DREAM
-ED: https://wicg.github.io/construct-stylesheets/index.html
+ED: https://wicg.github.io/construct-stylesheets/
 Editor: Tab Atkins Jr., Google, http://xanthir.com/contact/
 Editor: Eric Willigers, Google, ericwilligers@google.com
 Editor: Rakina Zata Amni, Google, rakina@google.com

--- a/index.html
+++ b/index.html
@@ -1212,8 +1212,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 7d8ce2d953ffaca8e344c0dab76f68fc292738a6" name="generator">
-  <link href="https://wicg.github.io/construct-stylesheets/index.html" rel="canonical">
+  <meta content="Bikeshed version a417ab651526c465cf0395da21ea73b0ffc2784e" name="generator">
+  <link href="https://wicg.github.io/construct-stylesheets/" rel="canonical">
+  <meta content="37c3f2d5c3cfcf7484c763561fece2b1efa3fc5d" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1460,11 +1461,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Constructable Stylesheet Objects</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-11-14">14 November 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2018-12-11">11 December 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://wicg.github.io/construct-stylesheets/index.html">https://wicg.github.io/construct-stylesheets/index.html</a>
+     <dd><a class="u-url" href="https://wicg.github.io/construct-stylesheets/">https://wicg.github.io/construct-stylesheets/</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/WICG/construct-stylesheets/issues/">GitHub</a>
      <dt class="editor">Editors:
@@ -1476,7 +1477,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 14 November 2018,
+In addition, as of 11 December 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>


### PR DESCRIPTION
Dropping the index.html works fine, and is generally preferred both
because it's shorter and it avoids exposing internal technical details
about which filename is used to serve responses for a directory.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dbaron/construct-stylesheets/pull/67.html" title="Last updated on Dec 12, 2018, 2:32 AM GMT (25a999a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/67/37c3f2d...dbaron:25a999a.html" title="Last updated on Dec 12, 2018, 2:32 AM GMT (25a999a)">Diff</a>