### PR TITLE
Use observable array for adoptedStyleSheets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -187,35 +187,21 @@ Note that we're explicitly monkeypatching CSSOM. We are working on [merging this
 Using Constructed Stylesheets {#using-constructed-stylesheets}
 =============================
 
-<pre class='idl'>
+<!-- TODO: add back class='idl' after Web IDL parser updates -->
+<pre>
 partial interface DocumentOrShadowRoot {
-	attribute FrozenArray&lt;CSSStyleSheet> adoptedStyleSheets;
+	attribute ObservableArray&lt;CSSStyleSheet> adoptedStyleSheets;
 };
 </pre>
 
-<dl>
-	<dt><dfn attribute for=DocumentOrShadowRoot lt="adoptedStyleSheets">adoptedStyleSheets</dfn></dt>
-	<dd>
-		On getting, {{adoptedStyleSheets}} returns this {{DocumentOrShadowRoot}}'s [=adopted stylesheets=].
+The <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/840.html#observable-array-attribute-set-an-indexed-value">set an indexed value</a> algorithm for <dfn attribute for="DocumentOrShadowRoot"><code>adoptedStyleSheets</code></dfn>, given |value| and |index|, is the following:
+	1.	If |value|'s [=constructed flag=] is not set, or its [=constructor document=] is not equal to this {{DocumentOrShadowRoot}}'s [=node document=], throw a "{{NotAllowedError}}" {{DOMException}}.
+	1.	Include |value| in this {{DocumentOrShadowRoot}}'s [=document or shadow root CSS style sheets=], ordered after all style sheets derived from {{DocumentOrShadowRoot/styleSheets}}, and positioned relative to other constructed style sheets according to |index|.
 
-		On setting, {{adoptedStyleSheets}} performs the following steps:
-
-		1. Let |adopted| be the result of converting the given value to a FrozenArray&lt;CSSStyleSheet>
-
-		2. If any entry of |adopted| has its [=constructed flag=] not set, or its [=constructor document=] is not equal to this {{DocumentOrShadowRoot}}'s [=node document=], throw a "{{NotAllowedError}}" {{DOMException}}.
-
-		3. Set this {{DocumentOrShadowRoot}}'s [=adopted stylesheets=] to |adopted|.
-	</dd>
-</dl>
-
-Every {{DocumentOrShadowRoot}} has <dfn>adopted stylesheets</dfn>.
-
-The user agent must include all style sheets in the {{DocumentOrShadowRoot}}'s
-[=adopted stylesheets=] inside its <a>document or shadow root CSS style sheets</a>.
-
-These [=adopted stylesheets=] are ordered after all the other style sheets (i.e. those derived from {{DocumentOrShadowRoot/styleSheets}}).
+The <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/840.html#observable-array-attribute-delete-an-indexed-value">delete an indexed value</a> algorithm for {{adoptedStyleSheets}}, given |value| and |index|, is the following:
+	1.	Remove |value| from this {{DocumentOrShadowRoot}}'s [=document or shadow root CSS style sheets=] at the appropriate location, according to |index|.
+			<p class="note">|value| may appear more than once, which is why |index| is used to distinguish.</p>
 
 This specification defines the following [=adopting steps=] for {{ShadowRoot}} nodes, given |node| and <var ignore>oldDocument</var>:
 
-1. Set |node|'s {{adoptedStyleSheets}} to the empty list.
-
+1. <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/840.html#observable-array-attribute-clear">Clear</a> |node|'s {{adoptedStyleSheets}}.

--- a/index.html
+++ b/index.html
@@ -1167,6 +1167,18 @@ Possible extra rowspan handling
 		margin-left: auto;
 		margin-right: auto;
 	}
+	.overlarge {
+		/* Magic to create good table positioning:
+		   "content column" is 50ems wide at max; less on smaller screens.
+		   Extra space (after ToC + content) is empty on the right.
+
+		   1. When table < content column, centers table in column.
+		   2. When content < table < available, left-aligns.
+		   3. When table > available, fills available + scroll bar.
+		*/ 
+		display: grid;
+		grid-template-columns: minmax(0, 50em);
+	}
 	.overlarge > table {
 		/* limit preferred width of table */
 		max-width: 50em;
@@ -1176,7 +1188,6 @@ Possible extra rowspan handling
 
 	@media (min-width: 55em) {
 		.overlarge {
-			margin-left: calc(13px + 26.5rem - 50vw);
 			margin-right: calc(13px + 26.5rem - 50vw);
 			max-width: none;
 		}
@@ -1184,14 +1195,12 @@ Possible extra rowspan handling
 	@media screen and (min-width: 78em) {
 		body:not(.toc-inline) .overlarge {
 			/* 30.5em body padding 50em content area */
-			margin-left: calc(40em - 50vw) !important;
 			margin-right: calc(40em - 50vw) !important;
 		}
 	}
 	@media screen and (min-width: 90em) {
 		body:not(.toc-inline) .overlarge {
 			/* 4em html margin 30.5em body padding 50em content area */
-			margin-left: 0 !important;
 			margin-right: calc(84.5em - 100vw) !important;
 		}
 	}
@@ -1212,7 +1221,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 087ea90e1ebd0321c20373d89950d1c6b73d5df1" name="generator">
+  <meta content="Bikeshed version 8bc2fccb49a45a0af18c5e75ce18049d75f824b6" name="generator">
   <link href="https://wicg.github.io/construct-stylesheets/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1460,7 +1469,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Constructable Stylesheet Objects</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-01-02">2 January 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">A Collection of Interesting Ideas, <time class="dt-updated" datetime="2020-02-03">3 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1476,7 +1485,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 2 January 2020,
+In addition, as of 3 February 2020,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1684,31 +1693,27 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
      </ol>
    </dl>
    <h2 class="heading settled" data-level="5" id="using-constructed-stylesheets"><span class="secno">5. </span><span class="content">Using Constructed Stylesheets</span><a class="self-link" href="#using-constructed-stylesheets"></a></h2>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot①"><c- g>DocumentOrShadowRoot</c-></a> {
-  <c- b>attribute</c-> <c- b>FrozenArray</c->&lt;<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet⑨"><c- n>CSSStyleSheet</c-></a>> <a class="idl-code" data-link-type="attribute" data-type="FrozenArray<CSSStyleSheet>" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets"><c- g>adoptedStyleSheets</c-></a>;
+<pre>partial interface DocumentOrShadowRoot {
+  attribute ObservableArray&lt;CSSStyleSheet> adoptedStyleSheets;
 };
 </pre>
-   <dl>
-    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="DocumentOrShadowRoot" data-dfn-type="attribute" data-export id="dom-documentorshadowroot-adoptedstylesheets"><code>adoptedStyleSheets</code></dfn>, <span> of type FrozenArray&lt;<a data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet①⓪">CSSStyleSheet</a>></span>
-    <dd>
-      On getting, <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets①">adoptedStyleSheets</a></code> returns this <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot②">DocumentOrShadowRoot</a></code>'s <a data-link-type="dfn" href="#adopted-stylesheets" id="ref-for-adopted-stylesheets">adopted stylesheets</a>. 
-     <p>On setting, <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets②">adoptedStyleSheets</a></code> performs the following steps:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>adopted</var> be the result of converting the given value to a FrozenArray&lt;CSSStyleSheet></p>
-      <li data-md>
-       <p>If any entry of <var>adopted</var> has its <a data-link-type="dfn" href="#cssstylesheet-constructed-flag" id="ref-for-cssstylesheet-constructed-flag⑧">constructed flag</a> not set, or its <a data-link-type="dfn" href="#cssstylesheet-constructor-document" id="ref-for-cssstylesheet-constructor-document②">constructor document</a> is not equal to this <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot③">DocumentOrShadowRoot</a></code>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>, throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror⑥">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code>.</p>
-      <li data-md>
-       <p>Set this <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot④">DocumentOrShadowRoot</a></code>'s <a data-link-type="dfn" href="#adopted-stylesheets" id="ref-for-adopted-stylesheets①">adopted stylesheets</a> to <var>adopted</var>.</p>
-     </ol>
-   </dl>
-   <p>Every <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot⑤">DocumentOrShadowRoot</a></code> has <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="adopted-stylesheets">adopted stylesheets</dfn>.</p>
-   <p>The user agent must include all style sheets in the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot⑥">DocumentOrShadowRoot</a></code>'s <a data-link-type="dfn" href="#adopted-stylesheets" id="ref-for-adopted-stylesheets②">adopted stylesheets</a> inside its <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets" id="ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">document or shadow root CSS style sheets</a>.</p>
-   <p>These <a data-link-type="dfn" href="#adopted-stylesheets" id="ref-for-adopted-stylesheets③">adopted stylesheets</a> are ordered after all the other style sheets (i.e. those derived from <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#dom-documentorshadowroot-stylesheets" id="ref-for-dom-documentorshadowroot-stylesheets">styleSheets</a></code>).</p>
+   <p>The <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/840.html#observable-array-attribute-set-an-indexed-value">set an indexed value</a> algorithm for <dfn class="dfn-paneled idl-code" data-dfn-for="DocumentOrShadowRoot" data-dfn-type="attribute" data-export id="dom-documentorshadowroot-adoptedstylesheets"><code>adoptedStyleSheets</code></dfn>, given <var>value</var> and <var>index</var>, is the following:</p>
+   <ol>
+    <li data-md>
+     <p>If <var>value</var>’s <a data-link-type="dfn" href="#cssstylesheet-constructed-flag" id="ref-for-cssstylesheet-constructed-flag⑧">constructed flag</a> is not set, or its <a data-link-type="dfn" href="#cssstylesheet-constructor-document" id="ref-for-cssstylesheet-constructor-document②">constructor document</a> is not equal to this <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot①">DocumentOrShadowRoot</a></code>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>, throw a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror⑥">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException⑦">DOMException</a></code>.</p>
+    <li data-md>
+     <p>Include <var>value</var> in this <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot②">DocumentOrShadowRoot</a></code>'s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets" id="ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">document or shadow root CSS style sheets</a>, ordered after all style sheets derived from <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-1/#dom-documentorshadowroot-stylesheets" id="ref-for-dom-documentorshadowroot-stylesheets">styleSheets</a></code>, and positioned relative to other constructed style sheets according to <var>index</var>.</p>
+   </ol>
+   <p>The <a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/840.html#observable-array-attribute-delete-an-indexed-value">delete an indexed value</a> algorithm for <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</a></code>, given <var>value</var> and <var>index</var>, is the following:</p>
+   <ol>
+    <li data-md>
+     <p>Remove <var>value</var> from this <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot③">DocumentOrShadowRoot</a></code>'s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets" id="ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets①">document or shadow root CSS style sheets</a> at the appropriate location, according to <var>index</var>.</p>
+     <p class="note" role="note"><var>value</var> may appear more than once, which is why <var>index</var> is used to distinguish.</p>
+   </ol>
    <p>This specification defines the following <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-adopt-ext" id="ref-for-concept-node-adopt-ext">adopting steps</a> for <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot">ShadowRoot</a></code> nodes, given <var>node</var> and <var>oldDocument</var>:</p>
    <ol>
     <li data-md>
-     <p>Set <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets③">adoptedStyleSheets</a></code> to the empty list.</p>
+     <p><a href="https://pr-preview.s3.amazonaws.com/heycam/webidl/pull/840.html#observable-array-attribute-clear">Clear</a> <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets①">adoptedStyleSheets</a></code>.</p>
    </ol>
   </main>
   <div data-fill-with="conformance">
@@ -1860,7 +1865,6 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#adopted-stylesheets">adopted stylesheets</a><span>, in §5</span>
    <li><a href="#dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</a><span>, in §5</span>
    <li><a href="#dom-cssstylesheetinit-alternate">alternate</a><span>, in §3</span>
    <li><a href="#cssstylesheet-constructed-flag">constructed flag</a><span>, in §3</span>
@@ -1902,7 +1906,6 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
    <ul>
     <li><a href="#ref-for-cssstylesheet①">3. Constructing Stylesheets</a> <a href="#ref-for-cssstylesheet②">(2)</a> <a href="#ref-for-cssstylesheet③">(3)</a> <a href="#ref-for-cssstylesheet④">(4)</a>
     <li><a href="#ref-for-cssstylesheet⑤">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-cssstylesheet⑥">(2)</a> <a href="#ref-for-cssstylesheet⑦">(3)</a> <a href="#ref-for-cssstylesheet⑧">(4)</a>
-    <li><a href="#ref-for-cssstylesheet⑨">5. Using Constructed Stylesheets</a> <a href="#ref-for-cssstylesheet①⓪">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-medialist">
@@ -1938,7 +1941,7 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
   <aside class="dfn-panel" data-for="term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">
    <a href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets">https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">5. Using Constructed Stylesheets</a>
+    <li><a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">5. Using Constructed Stylesheets</a> <a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-location">
@@ -2005,7 +2008,7 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
   <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
    <a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-documentorshadowroot①">5. Using Constructed Stylesheets</a> <a href="#ref-for-documentorshadowroot②">(2)</a> <a href="#ref-for-documentorshadowroot③">(3)</a> <a href="#ref-for-documentorshadowroot④">(4)</a> <a href="#ref-for-documentorshadowroot⑤">(5)</a> <a href="#ref-for-documentorshadowroot⑥">(6)</a>
+    <li><a href="#ref-for-documentorshadowroot①">5. Using Constructed Stylesheets</a> <a href="#ref-for-documentorshadowroot②">(2)</a> <a href="#ref-for-documentorshadowroot③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-shadowroot">
@@ -2222,10 +2225,6 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a> <a data-default="false" data-type="boolean " href="#dom-cssstylesheetinit-disabled"><code><c- g>disabled</c-></code></a> = <c- b>false</c->;
 };
 
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#documentorshadowroot" id="ref-for-documentorshadowroot①①"><c- g>DocumentOrShadowRoot</c-></a> {
-  <c- b>attribute</c-> <c- b>FrozenArray</c->&lt;<a class="n" data-link-type="idl-name" href="https://drafts.csswg.org/cssom-1/#cssstylesheet" id="ref-for-cssstylesheet⑨①"><c- n>CSSStyleSheet</c-></a>> <a class="idl-code" data-link-type="attribute" data-type="FrozenArray<CSSStyleSheet>" href="#dom-documentorshadowroot-adoptedstylesheets" id="ref-for-dom-documentorshadowroot-adoptedstylesheets④"><c- g>adoptedStyleSheets</c-></a>;
-};
-
 </pre>
   <aside class="dfn-panel" data-for="dictdef-cssstylesheetinit">
    <b><a href="#dictdef-cssstylesheetinit">#dictdef-cssstylesheetinit</a></b><b>Referenced in:</b>
@@ -2314,13 +2313,7 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
   <aside class="dfn-panel" data-for="dom-documentorshadowroot-adoptedstylesheets">
    <b><a href="#dom-documentorshadowroot-adoptedstylesheets">#dom-documentorshadowroot-adoptedstylesheets</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets">5. Using Constructed Stylesheets</a> <a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets①">(2)</a> <a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets②">(3)</a> <a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets③">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="adopted-stylesheets">
-   <b><a href="#adopted-stylesheets">#adopted-stylesheets</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-adopted-stylesheets">5. Using Constructed Stylesheets</a> <a href="#ref-for-adopted-stylesheets①">(2)</a> <a href="#ref-for-adopted-stylesheets②">(3)</a> <a href="#ref-for-adopted-stylesheets③">(4)</a>
+    <li><a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets">5. Using Constructed Stylesheets</a> <a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This is intended to illustrate https://github.com/heycam/webidl/pull/840. It is not ready to merge for various reasons.

I think this turned out OK. Handling of "document or shadow root CSS style sheets" is a bit vague, both before this change, after this change, and in the base CSSOM spec. When merging into CSSOM, we may want to rewrite all handling thereof to be 100% precise, but for now this seems relatively unambiguous.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/construct-stylesheets/pull/117.html" title="Last updated on Feb 3, 2020, 9:34 PM UTC (d7952a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/117/a62980d...domenic:d7952a8.html" title="Last updated on Feb 3, 2020, 9:34 PM UTC (d7952a8)">Diff</a>