### PR TITLE
Chore: stuff in the WICG should use CG-DRAFT

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,6 +2,7 @@
 Title: Constructable Stylesheet Objects
 Shortname: construct-stylesheets
 Level: 1
+Group: WICG
 Status: CG-DRAFT
 ED: https://wicg.github.io/construct-stylesheets/
 Editor: Tab Atkins Jr., Google, http://xanthir.com/contact/
@@ -218,4 +219,3 @@ These [=adopted stylesheets=] are ordered after all the other style sheets (i.e.
 This specification defines the following [=adopting steps=] for {{ShadowRoot}} nodes, given |node| and <var ignore>oldDocument</var>:
 
 1. Set |node|'s {{adoptedStyleSheets}} to the empty list.
-

--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Constructable Stylesheet Objects
 Shortname: construct-stylesheets
 Level: 1
-Status: DREAM
+Status: CG-DRAFT
 ED: https://wicg.github.io/construct-stylesheets/
 Editor: Tab Atkins Jr., Google, http://xanthir.com/contact/
 Editor: Eric Willigers, Google, ericwilligers@google.com


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/pull/121.html" title="Last updated on Feb 11, 2020, 11:06 PM UTC (ea37adf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/121/a62980d...ea37adf.html" title="Last updated on Feb 11, 2020, 11:06 PM UTC (ea37adf)">Diff</a>