### PR TITLE
Treat DocumentOrShadowRoot as an interface mixin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -188,7 +188,7 @@ Using Constructed Stylesheets {#using-constructed-stylesheets}
 =============================
 
 <pre class='idl'>
-partial interface DocumentOrShadowRoot {
+partial interface mixin DocumentOrShadowRoot {
 	attribute FrozenArray&lt;CSSStyleSheet> adoptedStyleSheets;
 };
 </pre>


### PR DESCRIPTION
Matching https://dom.spec.whatwg.org/#mixin-documentorshadowroot.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/construct-stylesheets/pull/124.html" title="Last updated on Feb 28, 2020, 4:50 PM UTC (93228b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/124/a62980d...foolip:93228b3.html" title="Last updated on Feb 28, 2020, 4:50 PM UTC (93228b3)">Diff</a>