### PR TITLE
Skip markup validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
+          VALIDATE_MARKUP: false


### PR DESCRIPTION
Currently fails bogusly on CSS errors
 file:/home/runner/work/construct-stylesheets/construct-stylesheets.w3c/index.html:587.29-587.32: error: CSS: “text-decoration-skip-ink”: Property “text-decoration-skip-ink” doesn't exist.
    file:/home/runner/work/construct-stylesheets/construct-stylesheets.w3c/index.html:599.30-599.32: error: CSS: “text-decoration-thickness”: Property “text-decoration-thickness” doesn't exist.
    file:/home/runner/work/construct-stylesheets/construct-stylesheets.w3c/index.html:600.17-601.1: error: CSS: “text-decoratin”: Parse Error.
    file:/home/runner/work/construct-stylesheets/construct-stylesheets.w3c/index.html:849.23-849.28: error: CSS: “border-block-width”: Property “border-block-width” doesn't exist.
follow up to #135