### PR TITLE
Refactor constructor and replaceSync() steps so CSS modules can reference them

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -78,16 +78,23 @@ dictionary CSSStyleSheetInit {
 	<dd>
 		When called, execute these steps:
 
-		1. Construct a new {{/CSSStyleSheet}} object |sheet| with the following properties:
-			* <a spec=cssom>location</a> set to the <a spec=html>base URL</a> of the [=associated Document=] for the [=current global object=]
-			* No <a spec=cssom>parent CSS style sheet</a>.
-			* No <a spec=cssom>owner node</a>.
-			* No <a spec=cssom>owner CSS rule</a>.
-			* <a spec=cssom>title</a> set to the {{CSSStyleSheetInit/title}} attribute of |options|.
+		1. Construct a new {{/CSSStyleSheet}} object |sheet|.
+		2. Run the steps to <a>set up a CSSStyleSheet</a> on |sheet| given |options|.
+		4. Return |sheet|.
+	</dd>
+
+	<dt>To <dfn export>set up a CSSStyleSheet</dfn></dt> on |sheet| given {{CSSStyleSheetInit}} |options|, run these steps:
+	<dd>
+		1. Set the following properties on |sheet|:
+			* Set <a spec=cssom>location</a> to the <a spec=html>base URL</a> of the [=associated Document=] for the [=current global object=]
+			* Set <a spec=cssom>parent CSS style sheet</a> to null.
+			* Set <a spec=cssom>owner node</a> to null.
+			* Set <a spec=cssom>owner CSS rule</a> to null.
+			* Set <a spec=cssom>title</a> to the {{CSSStyleSheetInit/title}} attribute of |options|.
 			* Set <a spec=cssom>alternate flag</a> if the {{CSSStyleSheetInit/alternate}} attribute of |options| is true, otherwise unset the <a spec=cssom>alternate flag</a>.
 			* Set <a spec=cssom>origin-clean flag</a>.
 			* Set [=constructed flag=].
-			* [=Constructor document=] set to the [=associated Document=] for the [=current global object=].
+			* Set [=Constructor document=] to the [=associated Document=] for the [=current global object=].
 		2. If the {{CSSStyleSheetInit/media}} attribute of |options| is a string,
 			<a>create a MediaList object</a> from the string
 			and assign it as |sheet|'s <a spec=cssom>media</a>.
@@ -95,7 +102,6 @@ dictionary CSSStyleSheetInit {
 			from the resulting string and set it as |sheet|'s <a spec=cssom>media</a>.
 		3. If the {{CSSStyleSheetInit/disabled}} attribute of |options| is true,
 			set |sheet|'s <a spec=cssom>disabled flag</a>.
-		4. Return |sheet|.
 	</dd>
 </dl>
 
@@ -176,10 +182,15 @@ Note that we're explicitly monkeypatching CSSOM. We are working on [merging this
 	<dd>
 		When called, execute these steps:
     	1. Let |sheet| be this {{/CSSStyleSheet}} object.
-		2. If |sheet|'s [=constructed flag=] is not set, or |sheet|'s [=disallow modification flag=] is set, throw a "{{NotAllowedError}}" {{DOMException}}.
-		3. Let |rules| be the result of running [=parse a list of rules=] from |text|. If |rules| is not a list of rules (i.e. an error occurred during parsing), set |rules| to an empty list.
-		4. If |rules| contains one or more <a>@import</a> rules, throw a "{{NotAllowedError}}" {{DOMException}}.
-		5. Set |sheet|'s [=CSS rules=] to |rules|.
+		2. Run the steps to <a>synchronously replace the rules of a CSSStyleSheet</a> on |sheet| given |text|.
+	</dd>
+
+	<dt>To <dfn export>synchronously replace the rules of a CSSStyleSheet</dfn></dt> on |sheet| given |text|, run these steps:
+	<dd>
+		1. If |sheet|'s [=constructed flag=] is not set, or |sheet|'s [=disallow modification flag=] is set, throw a "{{NotAllowedError}}" {{DOMException}}.
+		2. Let |rules| be the result of running [=parse a list of rules=] from |text|. If |rules| is not a list of rules (i.e. an error occurred during parsing), set |rules| to an empty list.
+		3. If |rules| contains one or more <a>@import</a> rules, throw a "{{NotAllowedError}}" {{DOMException}}.
+		4. Set |sheet|'s [=CSS rules=] to |rules|.
 	</dd>
 
 </dl>


### PR DESCRIPTION
The steps to create a CSS module ([spec draft](https://github.com/whatwg/html/pull/4898/)) should reference the steps in this spec to create a constructable stylesheet and run `replaceText()`. This will help ensure that the behavior of CSS modules and constructable stylesheets remains consistent as much as possible.

To make this possible, this change refactors the implementations of these algorithms into separate sets of steps that CSS modules can reference directly. By referencing these new algorithms instead of the public methods, this makes it clear that the behavior of CSS modules shouldn't change if the public methods for `CSSStyleSheet` are replaced by script.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dandclark/construct-stylesheets/pull/138.html" title="Last updated on May 3, 2021, 11:49 PM UTC (c6051b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/construct-stylesheets/138/112a3e7...dandclark:c6051b5.html" title="Last updated on May 3, 2021, 11:49 PM UTC (c6051b5)">Diff</a>